### PR TITLE
update iheatmapr_event

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: iheatmapr
 Type: Package
 Title: Interactive, Complex Heatmaps
-Version: 0.4.5
+Version: 0.4.6
 Authors@R: c(person("Alicia", "Schep",
                   email = "aschep@gmail.com",
                   role = c("aut", "cre"),

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -77,7 +77,7 @@ iheatmapr_event <- function(object,
     if (is(plots(object)[[curve]],"MainHeatmap")){
       out$value <- raw$z
     } 
-  } else if (event == "iheatmapr_selected"){
+  } else if (event == "iheatmapr_relayout"){
     out <- jsonlite::fromJSON(val)
     #out <- list(raw = raw)
   } 


### PR DESCRIPTION
The current implementation references the unsupported selection event but does not offer any code dealing with the supported relayout event - this generates "object 'out' not found" errors. The proposed change allows the function to return the relayout data as expected.