### PR TITLE
added argument show_colorbar=TRUE to main_heatmap.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -70,7 +70,7 @@ Suggests:
     roxygen2,
     covr,
     webshot
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1
 VignetteBuilder: knitr
 URL: https://github.com/ropensci/iheatmapr
 BugReports: https://github.com/ropensci/iheatmapr/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: iheatmapr
 Type: Package
 Title: Interactive, Complex Heatmaps
-Version: 0.4.8
+Version: 0.4.9
 Authors@R: c(person("Alicia", "Schep",
                   email = "aschep@gmail.com",
                   role = c("aut", "cre"),
@@ -38,7 +38,9 @@ Authors@R: c(person("Alicia", "Schep",
              person("Alex", "Vados", role = "ctb",
                   comment = "plotly.js library"), 
              person("Plotly", role = "cph",
-                  comment = "plotly.js library"))
+                  comment = "plotly.js library"), 
+             person("Frederick", "Boehm", role = "ctb",
+                  comment = "colorbars & main_heatmap"))
 Description: Make complex, interactive heatmaps. 'iheatmapr' includes a modular 
     system for iteratively building up complex heatmaps, as well as the 
     iheatmap() function for making relatively standard heatmaps.

--- a/R/main_heatmap.R
+++ b/R/main_heatmap.R
@@ -137,6 +137,7 @@ setup_tooltip_options <- function(row = TRUE,
 #' @param yname internal name for yaxis
 #' @param pname internal plot name
 #' @param source source name for use with shiny
+#' @param show_colorbar logical to indicate whether to show colorbar
 #' @param text text of value to display for data
 #' @param tooltip tooltip options, see \code{\link{setup_tooltip_options}}
 #' 
@@ -178,6 +179,7 @@ setMethod(main_heatmap, "matrix",
                    yname = "y",
                    pname = name,
                    source = "iheatmapr",
+                   show_colorbar = TRUE,
                    layout = list()){
             
             iheatmap_argument_checks(data, row_order, col_order, x, y)
@@ -191,7 +193,7 @@ setMethod(main_heatmap, "matrix",
                             xaxis = "x",
                             yaxis = "y",
                             colorbar = name,
-                            show_colorbar = TRUE,
+                            show_colorbar = show_colorbar,
                             data = data,
                             text = text,
                             tooltip = tooltip)

--- a/man/main_heatmap.Rd
+++ b/man/main_heatmap.Rd
@@ -16,7 +16,7 @@
   row_order = seq_len(nrow(data)), col_order = seq_len(ncol(data)),
   text = signif(data, digits = 3), tooltip = setup_tooltip_options(),
   xname = "x", yname = "y", pname = name, source = "iheatmapr",
-  layout = list())
+  show_colorbar = TRUE, layout = list())
 }
 \arguments{
 \item{data}{matrix}
@@ -63,6 +63,8 @@ subsequent elements sharing x axis}
 \item{pname}{internal plot name}
 
 \item{source}{source name for use with shiny}
+
+\item{show_colorbar}{logical to indicate whether to show colorbar}
 
 \item{layout}{list of layout attributes to pass to plotly, 
 eg. list(font = list(size = 15))}


### PR DESCRIPTION
I added an argument, show_colorbar = TRUE, to the main_heatmap function. This will allow the user to omit the colorbar if desired. With the default value of the argument set to TRUE, it shouldn't change behavior for users who don't wish to specify the show_colorbar argument.

